### PR TITLE
Add example Dockerfile to build environment from yaml file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM jupyter/scipy-notebook
+
+MAINTAINER Max Joseph <maxwell.b.joseph@colorado.edu>
+
+COPY environment.yml environment.yml
+
+RUN conda env create -f environment.yml
+
+RUN rm environment.yml
+
+# to have environments show up as kernels
+RUN conda install --channel=conda-forge nb_conda_kernels
+


### PR DESCRIPTION
This copies the environment.yml file into the build, creates the environment, deletes the environment.yml file, then installs `nb_conda_kernels` to make the environment appear as a kernel. Not sure whether this last part will play well with Jupyter Hub, or whether there is a better solution. 