### PR TITLE
Install environment deps in root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,9 @@ MAINTAINER Max Joseph <maxwell.b.joseph@colorado.edu>
 
 COPY environment.yml environment.yml
 
-RUN conda env create -f environment.yml
+RUN conda env update -n root -f environment.yml
+
+RUN conda info --envs
 
 RUN rm environment.yml
-
-# to have environments show up as kernels
-RUN conda install --channel=conda-forge nb_conda_kernels
 

--- a/environment.yml
+++ b/environment.yml
@@ -28,9 +28,8 @@ dependencies:
   - notebook
   - ipython
   - jupyter_contrib_nbextensions
-  - nb_conda
   - jupyterlab
-  - nb_conda_kernels
+
 
   - pip:
       # Utilities


### PR DESCRIPTION
This will install everything in the root conda environment.
I have also removed nb_conda and nb_conda_kernels so that
there is just one environment available and students don't
have to be exposed to the weirdness of having to select the
"root" or "default" environment, when these are in fact the
same.

@lwasser if you need other functionality from nb_conda, it
can be added again to the environment.yaml file!

Solves #2 